### PR TITLE
DELETE THIS PLS

### DIFF
--- a/project_functions.py
+++ b/project_functions.py
@@ -2649,7 +2649,7 @@ def insert_missing_file_data_in_db(file_id, url, metadata):
                 error_occured = True
 
     #check if metadata added
-    if db_entry[2] is None or db_entry[1].strip() == "":
+    if db_entry[2] is None or db_entry[1] is None or db_entry[1].strip() == "": # Check 1 and 2
         logger.debug("Tags not added - Add to db entry")
 
         added_tags = update_value("items", {"data": metadata},


### PR DESCRIPTION
Some git problem here, delete this

~~When I tried to transfer my work from laptop to nas, I did a export-import operation and it got the following error:~~

```python
DEBUG:project_functions:File also exist on FS - SKIP
DEBUG:root:Prepared Query: SELECT url,tags,data from items  WHERE id= ?
 data: [1]
DEBUG:project_functions:Check if tags are allowed
DEBUG:root:Prepared Query: SELECT option_value from config  WHERE option_name= ?
 data: ['use_tags_from_ydl']
Traceback (most recent call last):
  File "/mnt/d/YoutubeDL-Dowloader/yt_manager.py", line 163, in <module>
    NO_ERROR = start()
  File "/mnt/d/YoutubeDL-Dowloader/project_functions.py", line 68, in start
    return download_missing()
  File "/mnt/d/YoutubeDL-Dowloader/project_functions.py", line 1099, in download_missing
    data_inserted = insert_missing_file_data_in_db(file_already_exist_in_db[0], entry["url"], file_metadata)
  File "/mnt/d/YoutubeDL-Dowloader/project_functions.py", line 2652, in insert_missing_file_data_in_db
    if db_entry[2] is None or db_entry[1].strip() == "":
AttributeError: 'NoneType' object has no attribute 'strip'
```

~~I believe this was an error caused by not checking if `db_entry[1]` was empty at line 2652, making the change fixed it for me, but I didn't check the rest of it in depth~~

~~Also fixed some trivial typos in `show_help()`~~

~~> Also may check the spelling of the repository title (~~


